### PR TITLE
attach process object to returned promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ const promiseSpawnUid = (cmd, args, opts, extra) => {
   })
 
   p.stdin = proc.stdin
+  p.process = proc
   return p
 }
 

--- a/test/promise-spawn.js
+++ b/test/promise-spawn.js
@@ -166,6 +166,18 @@ t.test('expose process stdin', t => {
   setTimeout(() => p.stdin.end('o'))
 })
 
+t.test('expose process', t => {
+  const p = promiseSpawn('cat', [], { stdio: 'pipe' })
+  t.resolveMatch(p, {
+    code: 0,
+    signal: null,
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+  })
+  t.end()
+  setTimeout(() => p.process.exit(0))
+})
+
 t.test('infer ownership', t => {
   const {lstat} = fs
   t.teardown(() => fs.lstat = lstat)


### PR DESCRIPTION
exposing the process object on the promise will allow us to forward signals into a child process spawned by promise-spawn users, which is step one in allowing `npm run` scripts to handle their own signals