### PR TITLE
Update README with infer-owner info

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Spawn processes the way the npm cli likes to do.  Give it some options,
 it'll give you a Promise that resolves or rejects based on the results of
 the execution.
 
+Note: When the current user is root, this will use
+[`infer-owner`](http://npm.im/infer-owner) to find the owner of the current
+working directory, and run with that effective uid/gid.  Otherwise, it runs
+as the current user always.  (This helps prevent doing git checkouts and
+such, and leaving root-owned files lying around in user-owned locations.)
+
 ## USAGE
 
 ```js
@@ -54,4 +60,6 @@ spawned process.
 - `cwd` String, default `process.cwd()`.  Current working directory for
   running the script.  Also the argument to `infer-owner` to determine
   effective uid/gid when run as root on Unix systems.
-- Any other options for `child_process.spawn` can be passed as well.
+- Any other options for `child_process.spawn` can be passed as well, but
+  note that `uid` and `gid` will be overridden by the owner of the cwd when
+  run as root on Unix systems, or `null` otherwise.


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail. What it does and why it's being changed. -->
The functionality around `infer-owner` was removed in `v2.0` along with its documentation. But was decided to be added again and released as `v3.0` but the documentation was never updated.


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Removed in https://github.com/npm/promise-spawn/pull/7
Added back in https://github.com/npm/promise-spawn/pull/12