### PR TITLE
feat: remove infer-owner

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,24 +7,6 @@ const isPipe = (stdio = 'pipe', fd) =>
 
 // 'extra' object is for decorating the error a bit more
 const promiseSpawn = (cmd, args, opts = {}, extra = {}) => {
-  const cwd = opts.cwd || process.cwd()
-  return _promiseSpawn(cmd, args, {
-    ...opts,
-    cwd,
-  }, extra)
-}
-
-const stdioResult = (stdout, stderr, { stdioString, stdio }) =>
-  stdioString ? {
-    stdout: isPipe(stdio, 1) ? Buffer.concat(stdout).toString() : null,
-    stderr: isPipe(stdio, 2) ? Buffer.concat(stderr).toString() : null,
-  }
-  : {
-    stdout: isPipe(stdio, 1) ? Buffer.concat(stdout) : null,
-    stderr: isPipe(stdio, 2) ? Buffer.concat(stderr) : null,
-  }
-
-const _promiseSpawn = (cmd, args, opts, extra) => {
   let proc
   const p = new Promise((res, rej) => {
     proc = spawn(cmd, args, opts)
@@ -66,5 +48,15 @@ const _promiseSpawn = (cmd, args, opts, extra) => {
   p.process = proc
   return p
 }
+
+const stdioResult = (stdout, stderr, { stdioString, stdio }) =>
+  stdioString ? {
+    stdout: isPipe(stdio, 1) ? Buffer.concat(stdout).toString() : null,
+    stderr: isPipe(stdio, 2) ? Buffer.concat(stderr).toString() : null,
+  }
+  : {
+    stdout: isPipe(stdio, 1) ? Buffer.concat(stdout) : null,
+    stderr: isPipe(stdio, 2) ? Buffer.concat(stderr) : null,
+  }
 
 module.exports = promiseSpawn

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 const { spawn } = require('child_process')
-const inferOwner = require('infer-owner')
 
 const isPipe = (stdio = 'pipe', fd) =>
   stdio === 'pipe' || stdio === null ? true
@@ -9,13 +8,9 @@ const isPipe = (stdio = 'pipe', fd) =>
 // 'extra' object is for decorating the error a bit more
 const promiseSpawn = (cmd, args, opts = {}, extra = {}) => {
   const cwd = opts.cwd || process.cwd()
-  const isRoot = process.getuid && process.getuid() === 0
-  const { uid, gid } = isRoot ? inferOwner.sync(cwd) : {}
-  return promiseSpawnUid(cmd, args, {
+  return _promiseSpawn(cmd, args, {
     ...opts,
     cwd,
-    uid,
-    gid,
   }, extra)
 }
 
@@ -29,7 +24,7 @@ const stdioResult = (stdout, stderr, { stdioString, stdio }) =>
     stderr: isPipe(stdio, 2) ? Buffer.concat(stderr) : null,
   }
 
-const promiseSpawnUid = (cmd, args, opts, extra) => {
+const _promiseSpawn = (cmd, args, opts, extra) => {
   let proc
   const p = new Promise((res, rej) => {
     proc = spawn(cmd, args, opts)

--- a/package.json
+++ b/package.json
@@ -42,8 +42,5 @@
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
     "version": "4.6.2"
-  },
-  "dependencies": {
-    "infer-owner": "^1.0.4"
   }
 }

--- a/test/promise-spawn.js
+++ b/test/promise-spawn.js
@@ -1,7 +1,6 @@
 const t = require('tap')
 const Minipass = require('minipass')
 const EE = require('events')
-const fs = require('fs')
 
 const isPipe = (stdio = 'pipe', fd) =>
   stdio === 'pipe' || stdio === null ? true
@@ -214,34 +213,4 @@ t.test('expose process', t => {
   })
   t.end()
   setTimeout(() => p.process.exit(0))
-})
-
-t.test('infer ownership', t => {
-  const { lstatSync } = fs
-  t.teardown(() => fs.lstatSync = lstatSync)
-  fs.lstatSync = (path) => ({ uid: 420, gid: 69 })
-  const getuid = process.getuid
-  t.teardown(() => process.getuid = getuid)
-
-  t.test('as non-root, do not change uid/gid, regardless of arguments', t => {
-    process.getuid = () => 1234
-    return t.resolveMatch(promiseSpawn('whoami', [], { uid: 4321, gid: 9876 }), {
-      code: 0,
-      signal: null,
-      stdout: Buffer.from('UID undefined\nGID undefined\n'),
-      stderr: Buffer.alloc(0),
-    })
-  })
-
-  t.test('as root, change uid/gid to folder, regardless of arguments', t => {
-    process.getuid = () => 0
-    return t.resolveMatch(promiseSpawn('whoami', [], { uid: 4321, gid: 9876 }), {
-      code: 0,
-      signal: null,
-      stdout: Buffer.from('UID 420\nGID 69\n'),
-      stderr: Buffer.alloc(0),
-    })
-  })
-
-  t.end()
 })


### PR DESCRIPTION
BREAKING CHANGE: this module no longer attempts to infer a uid and gid for processes

now that we've removed this functionality as a feature from npm entirely, we need to remove it here
