### PR TITLE
fix: trim stdio strings before returning when stdioStrings is set

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,8 +51,8 @@ const promiseSpawn = (cmd, args, opts = {}, extra = {}) => {
 
 const stdioResult = (stdout, stderr, { stdioString, stdio }) =>
   stdioString ? {
-    stdout: isPipe(stdio, 1) ? Buffer.concat(stdout).toString() : null,
-    stderr: isPipe(stdio, 2) ? Buffer.concat(stderr).toString() : null,
+    stdout: isPipe(stdio, 1) ? Buffer.concat(stdout).toString().trim() : null,
+    stderr: isPipe(stdio, 2) ? Buffer.concat(stderr).toString().trim() : null,
   }
   : {
     stdout: isPipe(stdio, 1) ? Buffer.concat(stdout) : null,

--- a/test/promise-spawn.js
+++ b/test/promise-spawn.js
@@ -74,6 +74,9 @@ class MockProc extends EE {
       case 'pass':
         this.writeOut('OK :)')
         return this.exit(0)
+      case 'pass-nl':
+        this.writeOut('OK :)\n')
+        return this.exit(0)
       case 'fail':
         this.writeOut('not ok :(')
         this.writeErr('Some kind of helpful error')
@@ -116,6 +119,13 @@ t.test('pass', t => t.resolveMatch(promiseSpawn('pass', [], { stdioString: true 
   stdout: 'OK :)',
   stderr: '',
   a: 1,
+}))
+
+t.test('pass trim output', t => t.resolveMatch(promiseSpawn('pass-nl', [], { stdioString: true }), {
+  code: 0,
+  signal: null,
+  stdout: 'OK :)',
+  stderr: '',
 }))
 
 t.test('pass, default opts', t => t.resolveMatch(promiseSpawn('pass', []), {


### PR DESCRIPTION
BREAKING CHANGE: leading and trailing whitespace is no longer preserved when stdioStrings is set
