### PR TITLE
chore: remove unused devDep on minipass

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
     "@npmcli/template-oss": "4.13.0",
-    "minipass": "^4.0.0",
     "spawk": "^1.7.1",
     "tap": "^16.0.1"
   },


### PR DESCRIPTION
closes #63 