### PR TITLE
fix: parse `options.env` more similarly to `process.env`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,8 +100,8 @@ const spawnWithShell = (cmd, args, opts, extra) => {
     let pathToInitial
     try {
       pathToInitial = which.sync(initialCmd, {
-        path: (options.env && (options.env.PATH || options.env.Path)) || process.env.PATH,
-        pathext: (options.env && options.env.PATHEXT) || process.env.PATHEXT,
+        path: (options.env && findInObject(options.env, "PATH")) || process.env.PATH,
+        pathext: (options.env && findInObject(options.env, "PATHEXT")) || process.env.PATHEXT,
       }).toLowerCase()
     } catch (err) {
       pathToInitial = initialCmd.toLowerCase()
@@ -190,6 +190,16 @@ const stdioResult = (stdout, stderr, { stdioString = true, stdio }) => {
   }
 
   return result
+}
+
+// case insensitive lookup in an object
+const findInObject = (obj, key) => {
+  key = key.toLowerCase()
+  for (const objKey of Object.keys(obj)) {
+    if (objKey.toLowerCase() === key) {
+      return obj[objKey]
+    }
+  }
 }
 
 module.exports = promiseSpawn

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,7 @@ const spawnWithShell = (cmd, args, opts, extra) => {
     let pathToInitial
     try {
       pathToInitial = which.sync(initialCmd, {
-        path: (options.env && options.env.PATH) || process.env.PATH,
+        path: (options.env && (options.env.PATH || options.env.Path)) || process.env.PATH,
         pathext: (options.env && options.env.PATHEXT) || process.env.PATHEXT,
       }).toLowerCase()
     } catch (err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,8 +100,8 @@ const spawnWithShell = (cmd, args, opts, extra) => {
     let pathToInitial
     try {
       pathToInitial = which.sync(initialCmd, {
-        path: (options.env && findInObject(options.env, "PATH")) || process.env.PATH,
-        pathext: (options.env && findInObject(options.env, "PATHEXT")) || process.env.PATHEXT,
+        path: (options.env && findInObject(options.env, 'PATH')) || process.env.PATH,
+        pathext: (options.env && findInObject(options.env, 'PATHEXT')) || process.env.PATHEXT,
       }).toLowerCase()
     } catch (err) {
       pathToInitial = initialCmd.toLowerCase()
@@ -195,7 +195,7 @@ const stdioResult = (stdout, stderr, { stdioString = true, stdio }) => {
 // case insensitive lookup in an object
 const findInObject = (obj, key) => {
   key = key.toLowerCase()
-  for (const objKey of Object.keys(obj)) {
+  for (const objKey of Object.keys(obj).sort()) {
     if (objKey.toLowerCase() === key) {
       return obj[objKey]
     }


### PR DESCRIPTION
This fix attempts to parse `options.env` in a similar way to how it is parsed in `child_process.spawn`, namely by doing a simple sorted case-insensitive lookup for `path` and `pathext`.

The intent is to support folks who pass in to opts `{ env: ...process.env}`, as this removes the built in case insensitivity that is present on the original `process.env` object.