### PR TITLE
fix: reject with error from parent context on close

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ const promiseSpawn = (cmd, args, opts = {}, extra = {}) => {
   })
 
   // Create error here so we have a more useful stack trace when rejecting
-  const closeError = new Error('@npmcli/promise-spawn command failed')
+  const closeError = new Error('command failed')
 
   const stdout = []
   const stderr = []

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,54 +12,55 @@ const promiseSpawn = (cmd, args, opts = {}, extra = {}) => {
     return spawnWithShell(cmd, args, opts, extra)
   }
 
-  let proc
-
-  const p = new Promise((res, rej) => {
-    proc = spawn(cmd, args, opts)
-
-    const stdout = []
-    const stderr = []
-
-    const reject = er => rej(Object.assign(er, {
-      cmd,
-      args,
-      ...stdioResult(stdout, stderr, opts),
-      ...extra,
-    }))
-
-    proc.on('error', reject)
-
-    if (proc.stdout) {
-      proc.stdout.on('data', c => stdout.push(c)).on('error', reject)
-      proc.stdout.on('error', er => reject(er))
-    }
-
-    if (proc.stderr) {
-      proc.stderr.on('data', c => stderr.push(c)).on('error', reject)
-      proc.stderr.on('error', er => reject(er))
-    }
-
-    proc.on('close', (code, signal) => {
-      const result = {
-        cmd,
-        args,
-        code,
-        signal,
-        ...stdioResult(stdout, stderr, opts),
-        ...extra,
-      }
-
-      if (code || signal) {
-        rej(Object.assign(new Error('command failed'), result))
-      } else {
-        res(result)
-      }
-    })
+  let resolve, reject
+  const promise = new Promise((_resolve, _reject) => {
+    resolve = _resolve
+    reject = _reject
   })
 
-  p.stdin = proc.stdin
-  p.process = proc
-  return p
+  // Create error here so we have a more useful stack trace when rejecting
+  const commandError = new Error('command failed')
+
+  const stdout = []
+  const stderr = []
+
+  const getResult = (result) => ({
+    cmd,
+    args,
+    ...result,
+    ...stdioResult(stdout, stderr, opts),
+    ...extra,
+  })
+  const rejectWithOpts = (er, erOpts) => {
+    const resultError = getResult(erOpts)
+    reject(Object.assign(er, resultError))
+  }
+
+  const proc = spawn(cmd, args, opts)
+  promise.stdin = proc.stdin
+  promise.process = proc
+
+  proc.on('error', rejectWithOpts)
+
+  if (proc.stdout) {
+    proc.stdout.on('data', c => stdout.push(c))
+    proc.stdout.on('error', rejectWithOpts)
+  }
+
+  if (proc.stderr) {
+    proc.stderr.on('data', c => stderr.push(c))
+    proc.stderr.on('error', rejectWithOpts)
+  }
+
+  proc.on('close', (code, signal) => {
+    if (code || signal) {
+      rejectWithOpts(commandError, { code, signal })
+    } else {
+      resolve(getResult({ code, signal }))
+    }
+  })
+
+  return promise
 }
 
 const spawnWithShell = (cmd, args, opts, extra) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ const promiseSpawn = (cmd, args, opts = {}, extra = {}) => {
   })
 
   // Create error here so we have a more useful stack trace when rejecting
-  const commandError = new Error('command failed')
+  const closeError = new Error('@npmcli/promise-spawn command failed')
 
   const stdout = []
   const stderr = []
@@ -54,7 +54,7 @@ const promiseSpawn = (cmd, args, opts = {}, extra = {}) => {
 
   proc.on('close', (code, signal) => {
     if (code || signal) {
-      rejectWithOpts(commandError, { code, signal })
+      rejectWithOpts(closeError, { code, signal })
     } else {
       resolve(getResult({ code, signal }))
     }


### PR DESCRIPTION
This PR does two things:

- When the spawned process is closed with a `code` or `signal`, it rejects with an error from the parent context to preserve that more useful stack trace
- ~~Changes the error message from `command failed` to `@npmcli/promise-spawn command failed`. I feel like `command failed` looks too generic when thrown in the context of the npm CLI and this makes it clear that the error came from spawning something.~~ I removed this from the PR since it could be a breaking change since `npm` looks for this error message. It would be better to give this a better message further up the stack.

It also refactors a bit to remove one level of nesting. It uses the `Promise.withResolvers()` pattern to hoist the resolve and reject functions since none of the work actually needs to be done within the Promise executor.

### Example

Here's a before and after of `npm rebuild --loglevel verbose` of a failing `preinstall` script. Some output is removed for clarity/brevity.

**before**

```
npm verb title npm rebuild
npm verb argv "rebuild" "--loglevel" "verbose"
npm info run debug-init-cancel@1.0.0 preinstall  bash ./my-preinstall-script.sh
npm info run debug-init-cancel@1.0.0 preinstall { code: 1, signal: null }
npm verb stack Error: command failed
npm verb stack     at ChildProcess.<anonymous> (/Users/lukekarrys/Desktop/npm-debug/.versions/npm-10.5.2/node_modules/@npmcli/promise-spawn/lib/index.js:53:27)
npm verb stack     at ChildProcess.emit (node:events:518:28)
npm verb stack     at maybeClose (node:internal/child_process:1105:16)
npm verb stack     at Socket.<anonymous> (node:internal/child_process:457:11)
npm verb stack     at Socket.emit (node:events:518:28)
npm verb stack     at Pipe.<anonymous> (node:net:337:12)
npm verb pkgid debug-init-cancel@1.0.0
npm ERR! code 1
npm ERR! path /Users/lukekarrys/Desktop/npm-debug/debug-init-cancel
npm ERR! command failed
npm ERR! command sh -c bash ./my-preinstall-script.sh
npm ERR! Somes script output
npm ERR! Oh no, this will error!
npm verb exit 1
npm verb code 1
```

**after**
```
npm verb title npm rebuild
npm verb argv "rebuild" "--loglevel" "verbose"
npm info run debug-init-cancel@1.0.0 preinstall  bash ./my-preinstall-script.sh
npm info run debug-init-cancel@1.0.0 preinstall { code: 1, signal: null }
npm verb stack Error: command failed
npm verb stack     at promiseSpawn (/Users/lukekarrys/projects/npm/cli/node_modules/@npmcli/promise-spawn/lib/index.js:22:22)
npm verb stack     at spawnWithShell (/Users/lukekarrys/projects/npm/cli/node_modules/@npmcli/promise-spawn/lib/index.js:124:10)
npm verb stack     at promiseSpawn (/Users/lukekarrys/projects/npm/cli/node_modules/@npmcli/promise-spawn/lib/index.js:12:12)
npm verb stack     at runScriptPkg (/Users/lukekarrys/projects/npm/cli/node_modules/@npmcli/run-script/lib/run-script-pkg.js:75:13)
npm verb stack     at runScript (/Users/lukekarrys/projects/npm/cli/node_modules/@npmcli/run-script/lib/run-script.js:9:12)
npm verb stack     at /Users/lukekarrys/projects/npm/cli/workspaces/arborist/lib/arborist/rebuild.js:333:17
npm verb stack     at run (/Users/lukekarrys/projects/npm/cli/node_modules/promise-call-limit/dist/commonjs/index.js:67:22)
npm verb stack     at /Users/lukekarrys/projects/npm/cli/node_modules/promise-call-limit/dist/commonjs/index.js:84:9
npm verb stack     at new Promise (<anonymous>)
npm verb stack     at callLimit (/Users/lukekarrys/projects/npm/cli/node_modules/promise-call-limit/dist/commonjs/index.js:35:69)
npm verb pkgid debug-init-cancel@1.0.0
npm ERR! code 1
npm ERR! path /Users/lukekarrys/Desktop/npm-debug/debug-init-cancel
npm ERR! command failed
npm ERR! command sh -c bash ./my-preinstall-script.sh
npm ERR! Some script output
npm ERR! Oh no, this will error!
npm verb exit 1
npm verb code 1
```
