### PR TITLE
fix!: align to npm 11 node engine range

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/promise-spawn",
-  "version": "8.0.3",
+  "version": "8.0.2",
   "files": [
     "bin/",
     "lib/"
@@ -33,16 +33,16 @@
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^5.0.0",
-    "@npmcli/template-oss": "4.27.0",
+    "@npmcli/template-oss": "4.25.0",
     "spawk": "^1.7.1",
     "tap": "^16.0.1"
   },
   "engines": {
-    "node": "^18.17.0 || >=20.5.0"
+    "node": "^20.17.0 || >=22.9.0"
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.27.0",
+    "version": "4.25.0",
     "publish": true
   },
   "dependencies": {


### PR DESCRIPTION
This PR updates the Node.js engine requirement to align with npm 11.

## Changes
- Updated `engines.node` in package.json to `^20.17.0 || >=22.9.0`

## Breaking Change
This is a breaking change as it drops support for Node.js versions outside the specified range.

**New requirement:** Node.js `^20.17.0 || >=22.9.0`