### PR TITLE
fix: resolve the shell from a trusted PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ spawned process.
   the system default shell is used. If a String, that specific shell is used.
   When a shell is used, the given command runs from within that shell by
   concatenating the command and its escaped arguments and running the result.
-  This option is _not_ passed through to `child_process.spawn`.
+  The shell executable is resolved from the ambient process `PATH`
+  (`process.env.PATH`) rather than any `PATH` supplied via `opts.env`, so an
+  untrusted `opts.env.PATH` cannot substitute the shell interpreter. This option
+  is _not_ passed through to `child_process.spawn`.
 - Any other options for `child_process.spawn` can be passed as well.
 
 ### `promiseSpawn.open(arg, opts, extra)` -> `Promise`

--- a/README.md
+++ b/README.md
@@ -60,10 +60,12 @@ spawned process.
   An explicit shell path is used as provided. A bare shell name is resolved from
   the ambient process `PATH` (`process.env.PATH`) rather than any `PATH` supplied
   via `opts.env`, so an untrusted `opts.env.PATH` cannot substitute the shell
-  interpreter. On Windows, the current directory is not searched unless the
-  ambient `PATH` explicitly contains `.` or a relative directory. If a bare shell
-  name cannot be resolved, the returned promise rejects with `ENOENT`. This
-  option is _not_ passed through to `child_process.spawn`.
+  interpreter. Relative ambient `PATH` entries are resolved against
+  `process.cwd()` before `opts.cwd` is applied. On Windows, the current directory
+  is not searched unless the ambient `PATH` explicitly contains `.` or a relative
+  directory. If a bare shell name cannot be resolved, the returned promise
+  rejects with `ENOENT`. This option is _not_ passed through to
+  `child_process.spawn`.
 - Any other options for `child_process.spawn` can be passed as well.
 
 ### `promiseSpawn.open(arg, opts, extra)` -> `Promise`

--- a/README.md
+++ b/README.md
@@ -57,10 +57,13 @@ spawned process.
   the system default shell is used. If a String, that specific shell is used.
   When a shell is used, the given command runs from within that shell by
   concatenating the command and its escaped arguments and running the result.
-  The shell executable is resolved from the ambient process `PATH`
-  (`process.env.PATH`) rather than any `PATH` supplied via `opts.env`, so an
-  untrusted `opts.env.PATH` cannot substitute the shell interpreter. This option
-  is _not_ passed through to `child_process.spawn`.
+  An explicit shell path is used as provided. A bare shell name is resolved from
+  the ambient process `PATH` (`process.env.PATH`) rather than any `PATH` supplied
+  via `opts.env`, so an untrusted `opts.env.PATH` cannot substitute the shell
+  interpreter. On Windows, the current directory is not searched unless the
+  ambient `PATH` explicitly contains `.` or a relative directory. If a bare shell
+  name cannot be resolved, the returned promise rejects with `ENOENT`. This
+  option is _not_ passed through to `child_process.spawn`.
 - Any other options for `child_process.spawn` can be passed as well.
 
 ### `promiseSpawn.open(arg, opts, extra)` -> `Promise`

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 const { spawn } = require('child_process')
 const os = require('os')
+const path = require('path')
 const which = require('which')
 
 const escape = require('./escape.js')
@@ -63,6 +64,57 @@ const promiseSpawn = (cmd, args, opts = {}, extra = {}) => {
   return promise
 }
 
+const hasPath = (command) => process.platform === 'win32'
+  ? /[\\/:]/.test(command)
+  : command.includes('/')
+
+const unquotePath = (pathPart) =>
+  /^".*"$/.test(pathPart) ? pathPart.slice(1, -1) : pathPart
+
+const resolveShell = (command) => {
+  if (hasPath(command)) {
+    return command
+  }
+
+  const pathExt = process.env.PATHEXT
+  if (process.platform !== 'win32') {
+    return which.sync(command, {
+      path: process.env.PATH,
+      pathExt,
+      nothrow: true,
+    })
+  }
+
+  if (!process.env.PATH) {
+    return null
+  }
+
+  for (const pathPart of process.env.PATH.split(path.win32.delimiter)) {
+    if (!pathPart) {
+      continue
+    }
+
+    const directory = unquotePath(pathPart)
+    if (!directory) {
+      continue
+    }
+
+    const candidate = path.win32.resolve(directory, command)
+    const resolved = which.sync(candidate, {
+      pathExt,
+      nothrow: true,
+    })
+    if (resolved) {
+      return resolved
+    }
+  }
+
+  return null
+}
+
+const getNotFoundError = (command) =>
+  Object.assign(new Error(`not found: ${command}`), { code: 'ENOENT' })
+
 const spawnWithShell = (cmd, args, opts, extra) => {
   let command = opts.shell
   // if shell is set to true, we use a platform default. we can't let the core
@@ -73,14 +125,11 @@ const spawnWithShell = (cmd, args, opts, extra) => {
     command = process.platform === 'win32' ? (process.env.ComSpec || 'cmd.exe') : 'sh'
   }
 
-  // Resolve the shell from the trusted ambient PATH, not opts.env.PATH, to which
-  // a caller may prepend an untrusted node_modules/.bin whose `sh`/`cmd` bin
-  // would otherwise shadow the shell. Falls back to the bare name.
-  command = which.sync(command, {
-    path: process.env.PATH,
-    pathext: process.env.PATHEXT,
-    nothrow: true,
-  }) || command
+  const resolved = resolveShell(command)
+  if (!resolved) {
+    return Promise.reject(getNotFoundError(command))
+  }
+  command = resolved
 
   const options = { ...opts, shell: false }
   const realArgs = []
@@ -111,7 +160,7 @@ const spawnWithShell = (cmd, args, opts, extra) => {
     try {
       pathToInitial = which.sync(initialCmd, {
         path: (options.env && findInObject(options.env, 'PATH')) || process.env.PATH,
-        pathext: (options.env && findInObject(options.env, 'PATHEXT')) || process.env.PATHEXT,
+        pathExt: (options.env && findInObject(options.env, 'PATHEXT')) || process.env.PATHEXT,
       }).toLowerCase()
     } catch (err) {
       pathToInitial = initialCmd.toLowerCase()

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { spawn } = require('child_process')
+const { EventEmitter } = require('events')
 const os = require('os')
 const path = require('path')
 const which = require('which')
@@ -78,11 +79,14 @@ const resolveShell = (command) => {
 
   const pathExt = process.env.PATHEXT
   if (process.platform !== 'win32') {
-    return which.sync(command, {
+    const resolved = which.sync(command, {
       path: process.env.PATH,
       pathExt,
       nothrow: true,
     })
+    return !resolved || path.posix.isAbsolute(resolved)
+      ? resolved
+      : path.posix.resolve(process.cwd(), resolved)
   }
 
   if (!process.env.PATH) {
@@ -115,6 +119,25 @@ const resolveShell = (command) => {
 const getNotFoundError = (command) =>
   Object.assign(new Error(`not found: ${command}`), { code: 'ENOENT' })
 
+const rejectNotFound = (command, cmd, args, opts, extra) => {
+  const proc = new EventEmitter()
+  proc.stdin = null
+  proc.kill = () => false
+
+  const error = Object.assign(getNotFoundError(command), {
+    cmd,
+    args,
+    ...stdioResult([], [], opts),
+    ...extra,
+  })
+  const promise = Promise.reject(error)
+  promise.stdin = proc.stdin
+  promise.process = proc
+
+  process.nextTick(() => proc.emit('exit', null, null))
+  return promise
+}
+
 const spawnWithShell = (cmd, args, opts, extra) => {
   let command = opts.shell
   // if shell is set to true, we use a platform default. we can't let the core
@@ -127,7 +150,7 @@ const spawnWithShell = (cmd, args, opts, extra) => {
 
   const resolved = resolveShell(command)
   if (!resolved) {
-    return Promise.reject(getNotFoundError(command))
+    return rejectNotFound(command, cmd, args, opts, extra)
   }
   command = resolved
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,15 @@ const spawnWithShell = (cmd, args, opts, extra) => {
     command = process.platform === 'win32' ? (process.env.ComSpec || 'cmd.exe') : 'sh'
   }
 
+  // Resolve the shell from the trusted ambient PATH, not opts.env.PATH, to which
+  // a caller may prepend an untrusted node_modules/.bin whose `sh`/`cmd` bin
+  // would otherwise shadow the shell. Falls back to the bare name.
+  command = which.sync(command, {
+    path: process.env.PATH,
+    pathext: process.env.PATHEXT,
+    nothrow: true,
+  }) || command
+
   const options = { ...opts, shell: false }
   const realArgs = []
   let script = cmd

--- a/test/open.js
+++ b/test/open.js
@@ -3,10 +3,20 @@
 const spawk = require('spawk')
 const t = require('tap')
 const os = require('node:os')
+const path = require('node:path')
 
-// Stub which.sync so shell resolution returns the bare name, keeping the spawn()
-// assertions stable (trusted-PATH resolution is tested in test/shell.js).
+const pathMock = {
+  ...path,
+  posix: {
+    ...path.posix,
+    isAbsolute: () => true,
+  },
+}
+
+// Stub shell resolution so the spawn assertions remain stable; trusted-PATH
+// resolution is tested in test/shell.js.
 const promiseSpawn = t.mock('../lib/index.js', {
+  path: pathMock,
   which: { sync: (cmd) => cmd },
 })
 
@@ -168,6 +178,7 @@ t.test('process.platform === linux', (t) => {
       os: {
         release: () => 'Microsoft',
       },
+      path: pathMock,
       which: { sync: (cmd) => cmd },
     })
     const browser = process.env.BROWSER
@@ -193,6 +204,7 @@ t.test('process.platform === linux', (t) => {
       os: {
         release: () => 'microsoft',
       },
+      path: pathMock,
       which: { sync: (cmd) => cmd },
     })
     const browser = process.env.BROWSER

--- a/test/open.js
+++ b/test/open.js
@@ -4,7 +4,11 @@ const spawk = require('spawk')
 const t = require('tap')
 const os = require('node:os')
 
-const promiseSpawn = require('../lib/index.js')
+// Stub which.sync so shell resolution returns the bare name, keeping the spawn()
+// assertions stable (trusted-PATH resolution is tested in test/shell.js).
+const promiseSpawn = t.mock('../lib/index.js', {
+  which: { sync: (cmd) => cmd },
+})
 
 spawk.preventUnmatched()
 t.afterEach(() => {
@@ -164,6 +168,7 @@ t.test('process.platform === linux', (t) => {
       os: {
         release: () => 'Microsoft',
       },
+      which: { sync: (cmd) => cmd },
     })
     const browser = process.env.BROWSER
     process.env.BROWSER = '/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe'
@@ -188,6 +193,7 @@ t.test('process.platform === linux', (t) => {
       os: {
         release: () => 'microsoft',
       },
+      which: { sync: (cmd) => cmd },
     })
     const browser = process.env.BROWSER
     process.env.BROWSER = '/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe'

--- a/test/shell.js
+++ b/test/shell.js
@@ -19,7 +19,7 @@ const pathMock = {
 // behaviour has dedicated tests below.
 const promiseSpawn = t.mock('../lib/index.js', {
   path: pathMock,
-  which: { sync: (cmd) => cmd },
+  which: { sync: (cmd) => path.win32.basename(cmd) },
 })
 
 spawk.preventUnmatched()
@@ -61,6 +61,7 @@ const mockCwd = (t, cwd) => {
 
 t.test('sh', (t) => {
   t.test('runs in shell', async (t) => {
+    mockPlatform(t, 'win32')
     const proc = spawk.spawn('sh', ['-c', 'echo hello'], { shell: false })
       .stdout(Buffer.from('hello\n'))
 

--- a/test/shell.js
+++ b/test/shell.js
@@ -3,7 +3,11 @@
 const spawk = require('spawk')
 const t = require('tap')
 
-const promiseSpawn = require('../lib/index.js')
+// Stub which.sync so shell resolution returns the bare name, keeping the spawn()
+// assertions stable; the trusted-PATH behaviour has its own tests below.
+const promiseSpawn = t.mock('../lib/index.js', {
+  which: { sync: (cmd) => cmd },
+})
 
 spawk.preventUnmatched()
 t.afterEach(() => {
@@ -44,6 +48,52 @@ t.test('sh', (t) => {
   t.end()
 })
 
+t.test('shell interpreter resolution', (t) => {
+  t.test('resolves the shell from the ambient PATH, ignoring opts.env.PATH', async (t) => {
+    const calls = []
+    const promiseSpawnMock = t.mock('../lib/index.js', {
+      which: {
+        sync: (key, opts) => {
+          calls.push({ key, opts })
+          return '/usr/bin/sh'
+        },
+      },
+    })
+
+    const proc = spawk.spawn('/usr/bin/sh', ['-c', 'echo hello'], { shell: false })
+      .stdout(Buffer.from('hello\n'))
+
+    await promiseSpawnMock('echo', ['hello'], {
+      shell: 'sh',
+      env: { PATH: '/tmp/evil/node_modules/.bin' },
+    })
+
+    const shellCall = calls.find((c) => c.key === 'sh')
+    t.ok(shellCall, 'resolved the shell interpreter')
+    t.equal(shellCall.opts.path, process.env.PATH, 'used the ambient process PATH')
+    t.equal(shellCall.opts.nothrow, true, 'resolved with nothrow')
+    t.not(shellCall.opts.path, '/tmp/evil/node_modules/.bin',
+      'did not resolve against the untrusted opts.env.PATH')
+    t.ok(proc.called, 'spawned the resolved absolute shell path')
+  })
+
+  t.test('falls back to the bare shell name when not on the trusted PATH', async (t) => {
+    const promiseSpawnMock = t.mock('../lib/index.js', {
+      which: {
+        sync: () => null,
+      },
+    })
+
+    const proc = spawk.spawn('sh', ['-c', 'echo hello'], { shell: false })
+      .stdout(Buffer.from('hello\n'))
+
+    await promiseSpawnMock('echo', ['hello'], { shell: 'sh' })
+    t.ok(proc.called, 'spawned the bare shell name as a fallback')
+  })
+
+  t.end()
+})
+
 t.test('cmd', (t) => {
   t.test('runs in shell', async (t) => {
     const proc = spawk.spawn('cmd.exe', ['/d', '/s', '/c', 'echo hello'], {
@@ -53,6 +103,35 @@ t.test('cmd', (t) => {
       .stdout(Buffer.from('hello\n'))
 
     const result = await promiseSpawn('echo', ['hello'], { shell: 'cmd.exe' })
+    t.hasStrict(result, {
+      code: 0,
+      signal: undefined,
+      stdout: 'hello',
+      stderr: '',
+    })
+
+    t.ok(proc.called)
+  })
+
+  t.test('falls back to the bare initial cmd when it cannot be resolved', async (t) => {
+    const promiseSpawnMock = t.mock('../lib/index.js', {
+      which: {
+        sync: (key) => {
+          if (key === 'cmd.exe') {
+            return key
+          }
+          throw new Error('not found')
+        },
+      },
+    })
+
+    const proc = spawk.spawn('cmd.exe', ['/d', '/s', '/c', 'nope hello'], {
+      shell: false,
+      windowsVerbatimArguments: true,
+    })
+      .stdout(Buffer.from('hello\n'))
+
+    const result = await promiseSpawnMock('nope', ['hello'], { shell: 'cmd.exe' })
     t.hasStrict(result, {
       code: 0,
       signal: undefined,
@@ -121,6 +200,9 @@ t.test('cmd', (t) => {
     const promiseSpawnMock = t.mock('../lib/index.js', {
       which: {
         sync: (key) => {
+          if (key === 'cmd.exe') {
+            return key
+          }
           t.equal(key, 'dir')
           return 'dir.exe'
         },
@@ -147,6 +229,9 @@ t.test('cmd', (t) => {
     const promiseSpawnMock = t.mock('../lib/index.js', {
       which: {
         sync: (key) => {
+          if (key === 'cmd.exe') {
+            return key
+          }
           t.equal(key, 'dir')
           return 'dir.cmd'
         },
@@ -176,6 +261,9 @@ t.test('cmd', (t) => {
     const promiseSpawnMock = t.mock('../lib/index.js', {
       which: {
         sync: (key, opts) => {
+          if (key === 'cmd.exe') {
+            return key
+          }
           t.equal(key, 'dir')
           t.equal(opts.path, PATH)
           t.equal(opts.pathext, PATHEXT)
@@ -213,6 +301,9 @@ t.test('cmd', (t) => {
     const promiseSpawnMock = t.mock('../lib/index.js', {
       which: {
         sync: (key, opts) => {
+          if (key === 'cmd.exe') {
+            return key
+          }
           t.equal(key, 'dir')
           t.equal(opts.path, PATH)
           t.equal(opts.pathext, PATHEXT)

--- a/test/shell.js
+++ b/test/shell.js
@@ -7,10 +7,19 @@ const t = require('tap')
 const actualPromiseSpawn = require('../lib/index.js')
 const actualPlatform = process.platform
 
+const pathMock = {
+  ...path,
+  posix: {
+    ...path.posix,
+    isAbsolute: () => true,
+  },
+}
+
 // Keep ordinary spawn assertions stable across platforms; shell resolution
 // behaviour has dedicated tests below.
 const promiseSpawn = t.mock('../lib/index.js', {
-  which: { sync: (cmd) => path.win32.basename(cmd) },
+  path: pathMock,
+  which: { sync: (cmd) => cmd },
 })
 
 spawk.preventUnmatched()
@@ -39,6 +48,14 @@ const mockEnv = (t, key, value) => {
     } else {
       process.env[key] = original
     }
+  })
+}
+
+const mockCwd = (t, cwd) => {
+  const original = process.cwd
+  process.cwd = () => cwd
+  t.teardown(() => {
+    process.cwd = original
   })
 }
 
@@ -107,6 +124,33 @@ t.test('shell interpreter resolution', (t) => {
     t.ok(proc.called, 'spawned the resolved absolute shell path')
   })
 
+  t.test('anchors a relative shell result to the lookup cwd', async (t) => {
+    mockPlatform(t, 'linux')
+    mockEnv(t, 'PATH', '.')
+
+    const promiseSpawnMock = t.mock('../lib/index.js', {
+      which: {
+        sync: () => 'sh',
+      },
+    })
+    mockCwd(t, '/lookup')
+    const env = { PATH: '/execution/evil' }
+    const proc = spawk.spawn('/lookup/sh', ['-c', 'echo hello'], {
+      cwd: '/execution',
+      env,
+      shell: false,
+    })
+      .stdout(Buffer.from('hello\n'))
+
+    await promiseSpawnMock('echo', ['hello'], {
+      cwd: '/execution',
+      env,
+      shell: 'sh',
+    })
+
+    t.ok(proc.called, 'spawned the shell selected from the lookup cwd')
+  })
+
   t.test('rejects when a bare shell is not on the trusted PATH', async (t) => {
     mockPlatform(t, 'linux')
     const promiseSpawnMock = t.mock('../lib/index.js', {
@@ -115,10 +159,29 @@ t.test('shell interpreter resolution', (t) => {
       },
     })
 
-    await t.rejects(promiseSpawnMock('echo', ['hello'], { shell: 'missing-shell' }), {
+    const promise = promiseSpawnMock('echo', ['hello'], {
+      shell: 'missing-shell',
+      stdioString: false,
+    }, {
+      extra: 'property',
+    })
+    const exit = new Promise(resolve => {
+      promise.process.once('exit', (code, signal) => resolve({ code, signal }))
+    })
+
+    t.equal(promise.stdin, null)
+    t.equal(promise.process.stdin, null)
+    t.equal(promise.process.kill(), false)
+    await t.rejects(promise, {
       code: 'ENOENT',
       message: 'not found: missing-shell',
+      cmd: 'echo',
+      args: ['hello'],
+      stdout: Buffer.from(''),
+      stderr: Buffer.from(''),
+      extra: 'property',
     })
+    t.same(await exit, { code: null, signal: null })
   })
 
   t.test('preserves an explicit relative shell path', async (t) => {
@@ -313,6 +376,7 @@ t.test('cmd', (t) => {
 
   t.test('falls back to the bare initial cmd when it cannot be resolved', async (t) => {
     const promiseSpawnMock = t.mock('../lib/index.js', {
+      path: pathMock,
       which: {
         sync: (key) => {
           if (key === 'cmd.exe') {
@@ -396,6 +460,7 @@ t.test('cmd', (t) => {
 
   t.test('escapes when cmd is a .exe', async (t) => {
     const promiseSpawnMock = t.mock('../lib/index.js', {
+      path: pathMock,
       which: {
         sync: (key) => {
           if (key === 'cmd.exe') {
@@ -425,6 +490,7 @@ t.test('cmd', (t) => {
 
   t.test('double escapes when cmd is a .cmd', async (t) => {
     const promiseSpawnMock = t.mock('../lib/index.js', {
+      path: pathMock,
       which: {
         sync: (key) => {
           if (key === 'cmd.exe') {
@@ -457,6 +523,7 @@ t.test('cmd', (t) => {
     const PATHEXT = 'EXE'
 
     const promiseSpawnMock = t.mock('../lib/index.js', {
+      path: pathMock,
       which: {
         sync: (key, opts) => {
           if (key === 'cmd.exe') {
@@ -497,6 +564,7 @@ t.test('cmd', (t) => {
     const PATHEXT = 'EXE'
 
     const promiseSpawnMock = t.mock('../lib/index.js', {
+      path: pathMock,
       which: {
         sync: (key, opts) => {
           if (key === 'cmd.exe') {

--- a/test/shell.js
+++ b/test/shell.js
@@ -1,18 +1,46 @@
 'use strict'
 
+const path = require('path')
 const spawk = require('spawk')
 const t = require('tap')
 
-// Stub which.sync so shell resolution returns the bare name, keeping the spawn()
-// assertions stable; the trusted-PATH behaviour has its own tests below.
+const actualPromiseSpawn = require('../lib/index.js')
+const actualPlatform = process.platform
+
+// Keep ordinary spawn assertions stable across platforms; shell resolution
+// behaviour has dedicated tests below.
 const promiseSpawn = t.mock('../lib/index.js', {
-  which: { sync: (cmd) => cmd },
+  which: { sync: (cmd) => path.win32.basename(cmd) },
 })
 
 spawk.preventUnmatched()
 t.afterEach(() => {
   spawk.clean()
 })
+
+const mockPlatform = (t, platform) => {
+  const platformDesc = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { ...platformDesc, value: platform })
+  t.teardown(() => {
+    Object.defineProperty(process, 'platform', platformDesc)
+  })
+}
+
+const mockEnv = (t, key, value) => {
+  const original = process.env[key]
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+  t.teardown(() => {
+    if (original === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = original
+    }
+  })
+}
 
 t.test('sh', (t) => {
   t.test('runs in shell', async (t) => {
@@ -50,6 +78,7 @@ t.test('sh', (t) => {
 
 t.test('shell interpreter resolution', (t) => {
   t.test('resolves the shell from the ambient PATH, ignoring opts.env.PATH', async (t) => {
+    mockPlatform(t, 'linux')
     const calls = []
     const promiseSpawnMock = t.mock('../lib/index.js', {
       which: {
@@ -71,30 +100,199 @@ t.test('shell interpreter resolution', (t) => {
     const shellCall = calls.find((c) => c.key === 'sh')
     t.ok(shellCall, 'resolved the shell interpreter')
     t.equal(shellCall.opts.path, process.env.PATH, 'used the ambient process PATH')
+    t.equal(shellCall.opts.pathExt, process.env.PATHEXT, 'used the ambient PATHEXT')
     t.equal(shellCall.opts.nothrow, true, 'resolved with nothrow')
     t.not(shellCall.opts.path, '/tmp/evil/node_modules/.bin',
       'did not resolve against the untrusted opts.env.PATH')
     t.ok(proc.called, 'spawned the resolved absolute shell path')
   })
 
-  t.test('falls back to the bare shell name when not on the trusted PATH', async (t) => {
+  t.test('rejects when a bare shell is not on the trusted PATH', async (t) => {
+    mockPlatform(t, 'linux')
     const promiseSpawnMock = t.mock('../lib/index.js', {
       which: {
         sync: () => null,
       },
     })
 
-    const proc = spawk.spawn('sh', ['-c', 'echo hello'], { shell: false })
+    await t.rejects(promiseSpawnMock('echo', ['hello'], { shell: 'missing-shell' }), {
+      code: 'ENOENT',
+      message: 'not found: missing-shell',
+    })
+  })
+
+  t.test('preserves an explicit relative shell path', async (t) => {
+    mockPlatform(t, 'linux')
+    const calls = []
+    const promiseSpawnMock = t.mock('../lib/index.js', {
+      which: {
+        sync: (key) => {
+          calls.push(key)
+          return key
+        },
+      },
+    })
+
+    const proc = spawk.spawn('./tools/sh', ['-c', 'echo hello'], {
+      cwd: '/tmp/project',
+      shell: false,
+    })
       .stdout(Buffer.from('hello\n'))
 
-    await promiseSpawnMock('echo', ['hello'], { shell: 'sh' })
-    t.ok(proc.called, 'spawned the bare shell name as a fallback')
+    await promiseSpawnMock('echo', ['hello'], {
+      cwd: '/tmp/project',
+      shell: './tools/sh',
+    })
+
+    t.same(calls, [], 'did not resolve an explicit shell path')
+    t.ok(proc.called, 'passed the explicit path through to spawn')
+  })
+
+  t.end()
+})
+
+t.test('Windows shell interpreter resolution', (t) => {
+  t.test('checks only path-qualified ambient PATH candidates', async (t) => {
+    mockPlatform(t, 'win32')
+    mockEnv(t, 'PATH', 'C:\\first;;"";"C:\\Program Files\\trusted";C:\\last')
+    mockEnv(t, 'PATHEXT', '.EXE;.CMD')
+
+    const shellCalls = []
+    const trustedShell = 'C:\\Program Files\\trusted\\cmd.exe'
+    const promiseSpawnMock = t.mock('../lib/index.js', {
+      which: {
+        sync: (key, opts) => {
+          if (key === 'echo') {
+            return 'echo.exe'
+          }
+          shellCalls.push({ key, opts })
+          return key === trustedShell ? key : null
+        },
+      },
+    })
+
+    const proc = spawk.spawn(trustedShell, ['/d', '/s', '/c', 'echo hello'], {
+      shell: false,
+      windowsVerbatimArguments: true,
+    })
+      .stdout(Buffer.from('hello\n'))
+
+    await promiseSpawnMock('echo', ['hello'], {
+      shell: 'cmd.exe',
+      env: { PATH: 'C:\\evil' },
+    })
+
+    t.same(shellCalls.map(({ key }) => key), [
+      'C:\\first\\cmd.exe',
+      trustedShell,
+    ])
+    for (const { opts } of shellCalls) {
+      t.equal(opts.pathExt, '.EXE;.CMD')
+      t.equal(opts.nothrow, true)
+      t.notOk(opts.path, 'did not perform a bare PATH search')
+    }
+    t.ok(proc.called)
+  })
+
+  t.test('rejects when no Windows PATH candidate exists', async (t) => {
+    mockPlatform(t, 'win32')
+    mockEnv(t, 'PATH', 'C:\\first;C:\\last')
+
+    const promiseSpawnMock = t.mock('../lib/index.js', {
+      which: {
+        sync: () => null,
+      },
+    })
+
+    await t.rejects(promiseSpawnMock('echo', ['hello'], { shell: 'missing.exe' }), {
+      code: 'ENOENT',
+      message: 'not found: missing.exe',
+    })
+  })
+
+  t.test('rejects when the ambient Windows PATH is missing', async (t) => {
+    mockPlatform(t, 'win32')
+    mockEnv(t, 'PATH', undefined)
+    const calls = []
+    const promiseSpawnMock = t.mock('../lib/index.js', {
+      which: {
+        sync: (key) => {
+          calls.push(key)
+          return key
+        },
+      },
+    })
+
+    await t.rejects(promiseSpawnMock('echo', ['hello'], { shell: 'missing.exe' }), {
+      code: 'ENOENT',
+      message: 'not found: missing.exe',
+    })
+    t.same(calls, [], 'did not perform any executable lookup')
+  })
+
+  t.test('preserves an explicit Windows shell path', async (t) => {
+    mockPlatform(t, 'win32')
+    const calls = []
+    const shell = '.\\tools\\cmd.exe'
+    const promiseSpawnMock = t.mock('../lib/index.js', {
+      which: {
+        sync: (key) => {
+          calls.push(key)
+          return 'echo.exe'
+        },
+      },
+    })
+
+    const proc = spawk.spawn(shell, ['/d', '/s', '/c', 'echo hello'], {
+      cwd: 'C:\\project',
+      shell: false,
+      windowsVerbatimArguments: true,
+    })
+      .stdout(Buffer.from('hello\n'))
+
+    await promiseSpawnMock('echo', ['hello'], {
+      cwd: 'C:\\project',
+      shell,
+    })
+
+    t.same(calls, ['echo'], 'only resolved the command run inside cmd')
+    t.ok(proc.called, 'passed the explicit shell path through to spawn')
+  })
+
+  t.test('does not select a shell from the current directory', {
+    skip: actualPlatform !== 'win32',
+  }, async (t) => {
+    const fixture = t.testdir({
+      cwd: { 'cmd.exe': '' },
+      trusted: { 'cmd.exe': '' },
+    })
+    const originalCwd = process.cwd()
+    const cwd = path.join(fixture, 'cwd')
+    const trusted = path.join(fixture, 'trusted')
+    const trustedShell = path.join(trusted, 'cmd.exe')
+
+    mockEnv(t, 'PATH', trusted)
+    mockEnv(t, 'PATHEXT', '.EXE')
+    mockEnv(t, 'NoDefaultCurrentDirectoryInExePath', '1')
+    t.teardown(() => process.chdir(originalCwd))
+    process.chdir(cwd)
+
+    const proc = spawk.spawn(trustedShell, ['/d', '/s', '/c', 'echo hello'], {
+      shell: false,
+      windowsVerbatimArguments: true,
+    })
+      .stdout(Buffer.from('hello\n'))
+
+    await actualPromiseSpawn('echo', ['hello'], { shell: 'cmd.exe' })
+    t.ok(proc.called, 'spawned the shell from the trusted PATH')
   })
 
   t.end()
 })
 
 t.test('cmd', (t) => {
+  mockPlatform(t, 'linux')
+
   t.test('runs in shell', async (t) => {
     const proc = spawk.spawn('cmd.exe', ['/d', '/s', '/c', 'echo hello'], {
       shell: false,
@@ -266,7 +464,7 @@ t.test('cmd', (t) => {
           }
           t.equal(key, 'dir')
           t.equal(opts.path, PATH)
-          t.equal(opts.pathext, PATHEXT)
+          t.equal(opts.pathExt, PATHEXT)
           return 'dir.exe'
         },
       },
@@ -306,7 +504,7 @@ t.test('cmd', (t) => {
           }
           t.equal(key, 'dir')
           t.equal(opts.path, PATH)
-          t.equal(opts.pathext, PATHEXT)
+          t.equal(opts.pathExt, PATHEXT)
           return 'dir.exe'
         },
       },


### PR DESCRIPTION
`spawnWithShell` passed the bare shell name to `spawn`, which resolves it against `opts.env.PATH`, so a caller that leads that PATH with an untrusted `node_modules/.bin` let a dependency's `sh`/`cmd` bin shadow the shell. Resolve the shell from the ambient `process.env.PATH` instead, with a fallback to the bare name.